### PR TITLE
DateTime error fix

### DIFF
--- a/fixed/nusoap_base.php
+++ b/fixed/nusoap_base.php
@@ -929,7 +929,7 @@ class nusoap_base
             $sec = time();
             $usec = 0;
         }
-        $dtx = new DateTime("@$sec");
+        $dtx = new \DateTime("@$sec");
 
         return
             date_format($dtx, 'Y-m-d H:i:s') . '.' . sprintf('%06d', $usec);

--- a/src/nusoap_base.php
+++ b/src/nusoap_base.php
@@ -929,7 +929,7 @@ class nusoap_base
             $sec = time();
             $usec = 0;
         }
-        $dtx = new DateTime("@$sec");
+        $dtx = new \DateTime("@$sec");
 
         return
             date_format($dtx, 'Y-m-d H:i:s') . '.' . sprintf('%06d', $usec);


### PR DESCRIPTION
I've found an error on PHP 8.1:
`LEVEL: 1 (E_ERROR)
FILE:
/vendor/nguyenanhung/nusoap/src/nusoap_base.php
LINE: 932
TEXT:
Throwable; type: [Error]; code: [0]; message: [Class "nguyenanhung\MyNuSOAP\DateTime" not found]; err level: [1 (E_ERROR)]`

Added global namespace to DateTime, please check it.